### PR TITLE
Improve quality of coverage reports by parsing source files for functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,52 @@ Coverage.jl
 
 **"Take Julia test coverage results and do useful things with them."**
 
-Right now, that is submitting them to [Coveralls.io](https://coveralls.io), a test-coverage tracking tool that integrates with your continuous integration solution (e.g. [TravisCI](https://travis-ci.org/)).
+## Working locally
+
+### Code coverage
+
+Navigate to your test directory, and start julia like this:
+```sh
+julia --code-coverage=user
+```
+or, if you're running julia 0.4 or higher,
+```sh
+julia --code-coverage=user --inline=no
+```
+(Turning off inlining gives substantially more accurate results.)
+
+Then, run your tests (e.g., `include("runtests.jl")`) and quit julia.
+
+Finally, navigate to the top-level directory of your package, restart julia (with no special flags this time), and analyze coverage using
+```julia
+using Coverage
+covered, tot = coverage_folder()  # defaults to src/; alternatively, supply the folder name as a string
+```
+The fraction of total coverage is equal to `covered/tot`.
+
+### Memory allocation
+
+Start julia with
+```sh
+julia --track-allocation=user
+```
+Then:
+- Run whatever commands you wish to test. This first run is to ensure that everything is compiled (because compilation allocates memory).
+- Call `clear_malloc_data()` (or, if running julia 0.4 or higher, `Profile.clear_malloc_data()`)
+- Run your commands again
+- Quit julia
+
+Finally, navigate to the directory holding your source code. Start julia (without command-line flags), and analyze the results using
+```julia
+using Coverage
+analyze_malloc(dirnames)  # could be "." for the current directory, or "src", etc.
+```
+This will return a vector of `MallocInfo` objects, specifying the number of bytes allocated, the file name, and the line number.
+These are sorted in increasing order of allocation size.
+
+## Using Coveralls
+
+[Coveralls.io](https://coveralls.io) is a test-coverage tracking tool that integrates with your continuous integration solution (e.g. [TravisCI](https://travis-ci.org/)).
 
 ## Using Coverage.jl with Coveralls.io?
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.3-
 JSON
 Requests
 JuliaParser
+Compat

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.3-
 JSON
 Requests
+JuliaParser

--- a/src/Coverage.jl
+++ b/src/Coverage.jl
@@ -6,6 +6,7 @@
 module Coverage
 
     import JuliaParser.Parser
+    using Compat
 
     # process_cov
     # Given a .cov file, return the counts for each line, where the
@@ -80,6 +81,7 @@ module Coverage
         using Requests
         using Coverage
         using JSON
+        using Compat
 
         # coveralls_process_file
         # Given a .jl file, return the Coveralls.io dictionary for this
@@ -93,9 +95,9 @@ module Coverage
         # }
         export process_file
         function process_file(filename)
-            return ["name" => filename,
+            return @compat Dict("name" => filename,
                     "source" => readall(filename),
-                    "coverage" => amend_coverage_from_src!(process_cov(filename*".cov"), filename)]
+                    "coverage" => amend_coverage_from_src!(process_cov(filename*".cov"), filename))
         end
 
         # coveralls_process_src
@@ -103,7 +105,7 @@ module Coverage
         # and collect coverage statistics
         export process_folder
         function process_folder(folder="src")
-            source_files={}
+            source_files=Any[]
             filelist = readdir(folder)
             for file in filelist
                 fullfile = joinpath(folder,file)
@@ -147,17 +149,17 @@ module Coverage
         # }
         export submit, submit_token
         function submit(source_files)
-            data = ["service_job_id" => ENV["TRAVIS_JOB_ID"],
+            data = @compat Dict("service_job_id" => ENV["TRAVIS_JOB_ID"],
                     "service_name" => "travis-ci",
-                    "source_files" => source_files]
+                    "source_files" => source_files)
             r = Requests.post(URI("https://coveralls.io/api/v1/jobs"), files =
                 [FileParam(JSON.json(data),"application/json","json_file","coverage.json")])
             dump(r.data)
         end
 
         function submit_token(source_files)
-            data = ["repo_token" => ENV["REPO_TOKEN"],
-                    "source_files" => source_files]
+            data = @compat Dict("repo_token" => ENV["REPO_TOKEN"],
+                    "source_files" => source_files)
             r = post(URI("https://coveralls.io/api/v1/jobs"), files =
                 [FileParam(JSON.json(data),"application/json","json_file","coverage.json")])
             dump(r.data)

--- a/src/Coverage.jl
+++ b/src/Coverage.jl
@@ -11,7 +11,7 @@ module Coverage
     # process_cov
     # Given a .cov file, return the counts for each line, where the
     # lines that can't be counted are denoted with a -1
-    export process_cov, amend_coverage_from_src!
+    export process_cov, amend_coverage_from_src!, coverage_folder
     function process_cov(filename)
         if !isfile(filename)
             srcname, ext = splitext(filename)
@@ -61,6 +61,17 @@ module Coverage
         end
         coverage
     end
+    function coverage_folder(folder="src")
+        results = Coveralls.process_folder(folder)
+        tot = covered = 0
+        for item in results
+            coverage = item["coverage"]
+            tot += sum(x->x!=nothing, coverage)
+            covered += sum(x->x!=nothing && x>0, coverage)
+        end
+       covered, tot
+    end
+
     function_body_lines(ast) = function_body_lines!(Int[], ast, false)
     function_body_lines!(flines, arg, infunction) = flines
     function function_body_lines!(flines, node::LineNumberNode, infunction)

--- a/src/Coverage.jl
+++ b/src/Coverage.jl
@@ -11,7 +11,7 @@ module Coverage
     # process_cov
     # Given a .cov file, return the counts for each line, where the
     # lines that can't be counted are denoted with a -1
-    export process_cov, amend_coverage_from_src!, coverage_folder
+    export process_cov, amend_coverage_from_src!, coverage_folder, analyze_malloc
     function process_cov(filename)
         if !isfile(filename)
             srcname, ext = splitext(filename)

--- a/test/data/testparser.jl
+++ b/test/data/testparser.jl
@@ -1,5 +1,23 @@
-f1(x) = 2x
-if isdefined(:f1)
-  f2(x) = 3x
+if VERSION < v"0.4.0-dev"
+    using Docile
 end
-f3(x) = 4x
+# This line should have no code
+f2(x) = 2x
+if true
+  f3(x) = 3x
+end
+f4(x) = 4x; f5(x) = 5x
+# This line should have no code
+@doc """
+`f6(x)` multiplies `x` by 6
+""" ->
+f6(x) = 6x
+# This line should have no code
+@doc """
+`f7(x)` multiplies `x` by 7
+""" ->
+function f7(x)
+    7x
+end
+
+f8(x) = 8x

--- a/test/data/testparser.jl
+++ b/test/data/testparser.jl
@@ -1,0 +1,5 @@
+f1(x) = 2x
+if isdefined(:f1)
+  f2(x) = 3x
+end
+f3(x) = 4x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,13 @@ cd(Pkg.dir("Coverage")) do
     j = Coveralls.process_file(joinpath("test","data","Coverage.jl"))
 end
 
-run(`julia --code-coverage=user -e 'include("data/testparser.jl"); using Base.Test; @test f1(2) == 4'`)
-r = Coveralls.process_file(joinpath("data","testparser.jl"))
-@test r["coverage"][1:5] == [1,nothing,0,nothing,0]
+srcname = joinpath("data","testparser.jl")
+covname = srcname*".cov"
+isfile(covname) && rm(covname)
+cmdstr = "include(\"$srcname\"); using Base.Test; @test f2(2) == 4"
+run(`julia --code-coverage=user -e $cmdstr`)
+r = Coveralls.process_file(srcname)
+# The next one is the correct one, but julia & JuliaParser don't insert a line number after the 1-line @doc -> test
+# target = [nothing, nothing, nothing, nothing, 1, nothing, 0, nothing, 0, nothing, nothing, nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, 0, nothing, nothing, 0]
+target = [nothing, nothing, nothing, nothing, 1, nothing, 0, nothing, 0, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, 0, nothing, nothing, 0]
+@test r["coverage"][1:length(target)] == target

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,12 @@
 # https://github.com/IainNZ/Coverage.jl
 #######################################################################
 
-using Coverage
+using Coverage, Base.Test
 
-cd(Pkg.dir("Coverage"))
-j = Coveralls.process_file(joinpath("test","data","Coverage.jl"))
+cd(Pkg.dir("Coverage")) do
+    j = Coveralls.process_file(joinpath("test","data","Coverage.jl"))
+end
+
+run(`julia --code-coverage=user -e 'include("data/testparser.jl"); using Base.Test; @test f1(2) == 4'`)
+r = Coveralls.process_file(joinpath("data","testparser.jl"))
+@test r["coverage"][1:5] == [1,nothing,0,nothing,0]


### PR DESCRIPTION
This alters---and perhaps improves---our ability to quantify coverage. It leverages @jakebolewski's JuliaParser.jl to extract the beginning/end line range of "simple" function expressions. It then amends the coverage information by inserting 0 instead of `nothing` for functions that were never compiled.

This is not perfect. Here are deficits that I'm aware of currently:
- It misses functions defined inside a `for f in (:min, :max, ...) @eval begin...` style block (this error will contribute to overly-optimistic estimates of coverage)
- It falsely penalizes `end` statements and the initial `function f(...)` line in a multi-line function (this error will contribute to overly-pessimistic estimates of coverage)

There is also the genuine risk of the line count getting "out of sync", since the logic for extracting line numbers is not entirely trivial. I haven't seen it yet, but frankly I've only tested against a single source file.

I suspect both of these deficits may be fixable, so I am not certain this is yet worth merging. OTOH, I am not entirely certain I want to dump a huge amount of effort into this; if this is viewed as a step forward, perhaps we should go for it. But thanks to Jake it was surprisingly easy to get this far; maybe it wouldn't be so much harder to fix one or both of these problems (but I don't have any good ideas yet).
