### PR TITLE
Types are hierarchical, which might, just maybe, be important here

### DIFF
--- a/src/Coverage.jl
+++ b/src/Coverage.jl
@@ -226,9 +226,9 @@ module Coverage
 
             # Attempt to parse git info via git_info, unless the user explicitly disables it by setting git_info to nothing
             try
-                if typeof(git_info) == Function
+                if isa(git_info, Function)
                     data["git"] = git_info()
-                elseif typeof(git_info) == Dict
+                elseif isa(git_info, Dict)
                     data["git"] = git_info
                 end
             end


### PR DESCRIPTION
And with this fix, we should be able to get actual commit data on [this page](https://coveralls.io/r/JuliaLang/julia).  It turns out that the dict I was passing in is actually a `Dict{ASCIIString,Any}`, NOT a `Dict`, which makes all the difference.  :P