### PR TITLE
RFC: Modified Coverage to work with .{pid}.cov format

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,3 +26,26 @@ target = [nothing, nothing, nothing, nothing, 1, nothing, 0, nothing, 0, nothing
 covtarget = (sum(x->x != nothing && x > 0, target), sum(x->x != nothing, target))
 @test coverage_file(srcname) == covtarget
 @test coverage_folder("data") != covtarget
+
+if VERSION.minor >= 4
+    cd(Pkg.dir("Coverage")) do
+        j = Coveralls.process_file(joinpath("test","data","Coverage.jl"), "test/data")
+        analyze_malloc(joinpath("test","data"))
+    end
+
+    srcname = joinpath("data","testparser.jl")
+    covname = srcname*".cov"
+    isfile(covname) && rm(covname)
+    cmdstr = "include(\"$srcname\"); using Base.Test; @test f2(2) == 4"
+    run(`julia --code-coverage=user -e $cmdstr`)
+    r = Coveralls.process_file(srcname,"data")
+    # The next one is the correct one, but julia & JuliaParser don't insert a line number after the 1-line @doc -> test
+    # See https://github.com/JuliaLang/julia/issues/9663 (when this is fixed, can uncomment the next line on julia 0.4)
+    # target = [nothing, nothing, nothing, nothing, 1, nothing, 0, nothing, 0, nothing, nothing, nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, 0, nothing, nothing, 0]
+    target = [nothing, nothing, nothing, nothing, 1, nothing, 0, nothing, 0, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, 0, nothing, nothing, 0]
+    @test r["coverage"][1:length(target)] == target
+
+    covtarget = (sum(x->x != nothing && x > 0, target), sum(x->x != nothing, target))
+    @test coverage_file(srcname) == covtarget
+    @test coverage_folder("data") != covtarget
+end


### PR DESCRIPTION
I've tested this on Coveralls and Codecov. I have a PR I am about to submit to main Julia which will modify things so that each process writes `{filename}.{pid}.cov` instead of `{filename}.cov` as before. I've written some functions to handle the new format. I've checked also that my functions work with the old format and everything seems fine. `merge_coverage_counts` was lifted from CoverageBase - hopefully @timholy is ok with that.