### PR TITLE
codecov: isolating json data creation

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,4 +48,8 @@ if VERSION.minor >= 4
     covtarget = (sum(x->x != nothing && x > 0, target), sum(x->x != nothing, target))
     @test coverage_file(srcname) == covtarget
     @test coverage_folder("data") != covtarget
+
+    json_data = Codecov.build_json_data(Codecov.process_folder("data"))
+    @test typeof(json_data["coverage"]["data/Coverage.jl"]) == Array{Union{Int64,Void},1}
+
 end


### PR DESCRIPTION
Refactoring functions **submit()** and **submit_token()** to share the same
json data creation code. New function **build_json_data()**.