### PR TITLE
Fix #81

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1,5 +1,8 @@
 # Support functionality for amend_coverage_from_src!
 
+isevaldef(x) = Base.Meta.isexpr(x, :(=)) && Base.Meta.isexpr(x.args[1], :call) &&
+               x.args[1].args[1] == :eval
+
 function_body_lines(ast) = function_body_lines!(Int[], ast, false)
 function_body_lines!(flines, arg, infunction) = flines
 function function_body_lines!(flines, node::LineNumberNode, infunction)
@@ -16,9 +19,17 @@ function function_body_lines!(flines, ast::Expr, infunction)
             push!(flines, line)
         end
         return flines
+    elseif ast.head == :module
+        # Ignore automatically added eval definitions
+        args = ast.args[end].args
+        if isevaldef(args[1]) && isevaldef(args[2])
+            args = args[3:end]
+        end
+    else
+        args = ast.args
     end
     infunction |= isfuncexpr(ast)
-    for arg in ast.args
+    for arg in args
         flines = function_body_lines!(flines, arg, infunction)
     end
     flines

--- a/test/data/testparser.jl
+++ b/test/data/testparser.jl
@@ -21,3 +21,7 @@ function f7(x)
 end
 
 f8(x) = 8x
+
+# This line should have no code
+module TestModule
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,8 +22,8 @@ run(`julia --code-coverage=user -e $cmdstr`)
 r = process_file(srcname, "data")
 # The next one is the correct one, but julia & JuliaParser don't insert a line number after the 1-line @doc -> test
 # See https://github.com/JuliaLang/julia/issues/9663 (when this is fixed, can uncomment the next line on julia 0.4)
- target = Union{Int64,Void}[nothing, nothing, nothing, nothing, 1, nothing, 0, nothing, 0, nothing, nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, nothing, 0, nothing, nothing, 0]
-#target = Union{Int64,Void}[nothing, nothing, nothing, nothing, 1, nothing, 0, nothing, 0, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, 0, nothing, nothing, 0]
+target = Union{Int64,Void}[nothing, nothing, nothing, nothing, 1, nothing, 0, nothing, 0, nothing, nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, nothing, 0, nothing, nothing, 0, nothing, nothing, nothing, nothing]
+#target = Union{Int64,Void}[nothing, nothing, nothing, nothing, 1, nothing, 0, nothing, 0, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, 0, nothing, nothing, 0, nothing, nothing, nothing, nothing]
 @test r.coverage[1:length(target)] == target
 
 covtarget = (sum(x->x != nothing && x > 0, target), sum(x->x != nothing, target))


### PR DESCRIPTION
The problem is the `eval` definitions here, which have corresponding line number nodes since JuliaLang/julia@cb2dbda6e00b202c739b1bc0c068616878744984:

```julia
julia> :(module X end)
:(module X
    eval(x) = begin  # none, line 1:
            top(Core).eval(X,x)
        end
    eval(m,x) = begin  # none, line 1:
            top(Core).eval(m,x)
        end
    end)
```

Those `eval` definitons may not necessarily get hit, but probably shouldn't count against coverage.