### PR TITLE
Fix parser bug with baremodule

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -22,7 +22,7 @@ function function_body_lines!(flines, ast::Expr, infunction)
     elseif ast.head == :module
         # Ignore automatically added eval definitions
         args = ast.args[end].args
-        if isevaldef(args[1]) && isevaldef(args[2])
+        if length(args) >= 2 && isevaldef(args[1]) && isevaldef(args[2])
             args = args[3:end]
         end
     else

--- a/test/data/testparser.jl
+++ b/test/data/testparser.jl
@@ -25,3 +25,7 @@ f8(x) = 8x
 # This line should have no code
 module TestModule
 end
+
+# This line should have no code
+baremodule TestBareModule
+end


### PR DESCRIPTION
Fixes #94. Since a `baremodule` is empty checking if you attempt to access the first two arguments of its AST results in a `BoundsError`.